### PR TITLE
feat(shell): add modular config provider

### DIFF
--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -22,6 +22,53 @@ export type Env = z.infer<typeof ShellEnvVar>;
 export type Alias = z.infer<typeof ShellAlias>;
 export type PathItem = z.infer<typeof ShellPath>;
 
+export type Item = Env | Alias | PathItem;
+export type Shell = "bash" | "zsh" | "sh";
+
+function quote(value: string): string {
+  return `"${value.replace(/"/g, '\\"')}"`;
+}
+
+export class ShellConfig {
+  private envVars = new Map<string, string>();
+  private aliases = new Map<string, string>();
+  private paths: string[] = [];
+
+  collect(item: Item): void {
+    if (item.kind === "env") {
+      this.envVars.set(item.key, item.value);
+    } else if (item.kind === "alias") {
+      this.aliases.set(item.name, item.command);
+    } else if (item.kind === "path") {
+      this.paths.push(item.dir);
+    }
+  }
+
+  render(_shell: Shell): string {
+    const lines: string[] = [];
+    for (const [key, value] of this.envVars) {
+      lines.push(`export ${key}=${quote(value)}`);
+    }
+    if (this.paths.length > 0) {
+      const joined = this.paths.join(":");
+      lines.push(`export PATH=${quote(`${joined}:$PATH`)}`);
+    }
+    for (const [name, command] of this.aliases) {
+      const escaped = command.replace(/'/g, "'\\''");
+      lines.push(`alias ${name}='${escaped}'`);
+    }
+    return lines.join("\n");
+  }
+
+  renderAll(): Record<Shell, string> {
+    return {
+      bash: this.render("bash"),
+      zsh: this.render("zsh"),
+      sh: this.render("sh"),
+    };
+  }
+}
+
 type EnvInput = Omit<Env, "module" | "kind">;
 type AliasInput = Omit<Alias, "module" | "kind">;
 type PathInput = Omit<PathItem, "module" | "kind">;


### PR DESCRIPTION
## Summary
- add ShellConfig collector to gather env vars, aliases and paths
- generate shell profiles for bash, zsh and sh

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b57c728548832f9562b2e5acee5fe2