### PR TITLE
Add example configuration plan and profiles

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,13 @@
+# Examples
+
+This directory contains example configurations for the Dot Steward library.
+
+## Basic Plan
+
+`basic.plan.ts` demonstrates how to define a plan with multiple profiles and items:
+
+- A base profile that sets up a git config, editor environment variable, and updates the `$PATH`.
+- A Linux profile that installs packages with `apt`.
+- A macOS profile that uses `brew` to install formulas and casks.
+
+These examples are intended for illustration and do not execute any actions by themselves.

--- a/examples/basic.plan.ts
+++ b/examples/basic.plan.ts
@@ -1,0 +1,38 @@
+import {
+  plan,
+  profile,
+  apt,
+  brew,
+  command,
+  file,
+  shell,
+} from "@dot-steward/dot-steward";
+
+export const basicPlan = plan({
+  profiles: [
+    profile("base", {
+      items: [
+        command.cmd("check-git", "command -v git", "sudo apt-get update"),
+        file.ensure(
+          "gitconfig",
+          "~/.gitconfig",
+          "[user]\n  name = Example\n  email = example@example.com\n",
+        ),
+        shell.env("editor", "EDITOR", "vim"),
+        shell.path("localBin", "~/.local/bin"),
+      ],
+    }),
+    profile("linux", {
+      match: { os: "linux" },
+      items: [apt.pkg("curl"), apt.pkg("htop")],
+    }),
+    profile("mac", {
+      match: { os: "darwin" },
+      items: [
+        brew.tap("homebrew/cask"),
+        brew.formula("wget"),
+        brew.cask("visual-studio-code"),
+      ],
+    }),
+  ],
+});


### PR DESCRIPTION
## Summary
- add `examples` directory with basic plan showcasing base, Linux, and macOS profiles
- document example usage

## Testing
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68b57d004dcc832f82632775197e3502