### PR TITLE
feat: add module prepare stage

### DIFF
--- a/packages/brew/package.json
+++ b/packages/brew/package.json
@@ -9,6 +9,7 @@
     "test": "echo 'no tests'"
   },
   "dependencies": {
-    "@dot-steward/core": "workspace:*"
+    "@dot-steward/core": "workspace:*",
+    "@dot-steward/command": "workspace:*"
   }
 }

--- a/packages/brew/src/index.ts
+++ b/packages/brew/src/index.ts
@@ -1,4 +1,5 @@
 import { Base, z } from "@dot-steward/core";
+import { cmd, type Command } from "@dot-steward/command";
 
 export const BrewTap = Base.extend({
   module: z.literal("brew"),
@@ -46,4 +47,20 @@ export function cask(idOrInput: string | CaskInput): Cask {
     return { module: "brew", kind: "cask", id: idOrInput };
   }
   return { module: "brew", kind: "cask", ...idOrInput };
+}
+
+export function prepare(): Command[] {
+  return [
+    cmd(
+      "brew-install",
+      "command -v brew >/dev/null 2>&1",
+      
+      "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
+    ),
+    cmd(
+      "brew-bundle-tap",
+      "brew tap | grep -q '^homebrew/bundle$'",
+      "brew tap homebrew/bundle",
+    ),
+  ];
 }

--- a/packages/dot-steward/src/index.ts
+++ b/packages/dot-steward/src/index.ts
@@ -65,3 +65,20 @@ export interface Plan {
 export function plan(p: Plan): Plan {
   return p;
 }
+
+export async function prepare(plan: Plan): Promise<Item[]> {
+  const mods = new Set(
+    plan.profiles.flatMap((profile) => profile.items.map((item) => item.module)),
+  );
+  const items: Item[] = [];
+  for (const mod of mods) {
+    try {
+      const m: unknown = await import(`@dot-steward/${mod}`);
+      const fn = (m as { prepare?: () => Item[] }).prepare;
+      if (typeof fn === "function") items.push(...fn());
+    } catch {
+      // ignore modules that cannot be loaded
+    }
+  }
+  return items;
+}


### PR DESCRIPTION
## Summary
- add prepare stage to brew module ensuring Homebrew and bundle tap installed
- gather module prepare steps with new `prepare` helper
- load module prepare steps dynamically so modules act as self-contained plugins

## Testing
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68b57fca73dc832fa16e0ed2a0108d58