### PR TITLE
docs: add bun and biome agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Agent Guidelines
+
+This repository uses [Bun](https://bun.sh) as its package manager and script
+runner and [Biome](https://biomejs.dev) for code quality.
+
+## Bun
+
+- Install dependencies using `bun install`. Do not use other package managers.
+- Add or remove packages with `bun add` or `bun remove` and commit the
+  updated `bun.lock`.
+- Run project scripts with `bun run <script>`.
+
+## Biome
+
+- Lint the codebase with `bun run lint`.
+- Automatically fix lint issues with `bun run lint:fix`.
+- Format files with `bun run format`.
+- Biome configuration lives in `biome.json`; adhere to its rules.
+
+## Verification
+
+Before committing changes, make sure the following commands succeed:
+
+```
+bun run lint
+bun run test
+```
+


### PR DESCRIPTION
## Summary
- document bun package manager usage and biome lint/format rules for contributors
- add verification steps for linting and tests

## Testing
- `bun run format`
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68b58367375c832f91a421c88cd26718