### PR TITLE
Add tests and CI for core and plugins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Test
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.2.14
+      - run: bun install
+      - run: bun run lint
+      - run: bun run test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ runner and [Biome](https://biomejs.dev) for code quality.
   commits any resulting changes using the
   [`lucasilverentand/auto-commit`](https://github.com/lucasilverentand/auto-commit) action.
 - Biome configuration lives in `biome.json`; adhere to its rules.
+- Tests run on pull requests via `.github/workflows/test.yml`, which executes
+  `bun run lint` and `bun run test`.
 
 ## Verification
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,7 @@
   "types": "src/index.ts",
   "scripts": {
     "lint": "biome lint .",
-    "test": "echo 'no tests'"
+    "test": "bun test"
   },
   "dependencies": {
     "zod": "^3.22.4"

--- a/packages/core/src/__tests__/core.test.ts
+++ b/packages/core/src/__tests__/core.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { Base, OS, Plugin, z } from "..";
+
+class DummyPlugin extends Plugin<{ id: string }> {
+  name = "dummy";
+  schema = z.object({ id: z.string() });
+}
+
+describe("core", () => {
+  test("Base schema validates id", () => {
+    expect(Base.parse({ id: "abc" })).toEqual({ id: "abc" });
+    expect(() => Base.parse({ id: "" })).toThrow();
+  });
+
+  test("OS enum has expected options", () => {
+    expect(OS.options).toEqual(["darwin", "linux", "win32"]);
+    // @ts-expect-error invalid OS
+    expect(() => OS.parse("freebsd")).toThrow();
+  });
+
+  test("Plugin subclass holds name and schema", () => {
+    const plugin = new DummyPlugin();
+    expect(plugin.name).toBe("dummy");
+    expect(plugin.schema.parse({ id: "x" })).toEqual({ id: "x" });
+  });
+});

--- a/packages/dot-steward/package.json
+++ b/packages/dot-steward/package.json
@@ -6,7 +6,7 @@
   "types": "src/index.ts",
   "scripts": {
     "lint": "biome lint .",
-    "test": "echo 'no tests'"
+    "test": "bun test"
   },
   "dependencies": {
     "@dot-steward/core": "workspace:*",

--- a/packages/dot-steward/src/__tests__/dot-steward.test.ts
+++ b/packages/dot-steward/src/__tests__/dot-steward.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { Item, profile, plan, apt } from "..";
+
+describe("dot-steward", () => {
+  test("profile defaults items to empty array", () => {
+    const p = profile("id", { match: { os: "linux" } });
+    expect(p).toEqual({ id: "id", match: { os: "linux" }, items: [] });
+  });
+
+  test("plan returns given plan", () => {
+    const p = { profiles: [] };
+    expect(plan(p)).toBe(p);
+  });
+
+  test("Item schema parses plugin item", () => {
+    const item = apt.pkg("vim");
+    expect(Item.parse(item)).toEqual(item);
+  });
+});

--- a/packages/dot-steward/src/item.ts
+++ b/packages/dot-steward/src/item.ts
@@ -1,21 +1,15 @@
 import { z } from "@dot-steward/core";
 import { AptItem } from "@dot-steward/apt";
-import { BrewCask, BrewFormula, BrewTap } from "@dot-steward/brew";
+import { BrewItem } from "@dot-steward/brew";
 import { CommandItem } from "@dot-steward/command";
-import { FileDir, FileEnsure, FileSymlink } from "@dot-steward/file";
-import { ShellAlias, ShellEnvVar, ShellPath } from "@dot-steward/shell";
+import { FileItem } from "@dot-steward/file";
+import { ShellItem } from "@dot-steward/shell";
 
-export const Item = z.discriminatedUnion("plugin", [
+export const Item = z.union([
   CommandItem,
   AptItem,
-  BrewFormula,
-  BrewTap,
-  BrewCask,
-  FileEnsure,
-  FileDir,
-  FileSymlink,
-  ShellEnvVar,
-  ShellAlias,
-  ShellPath,
+  BrewItem,
+  FileItem,
+  ShellItem,
 ]);
 export type Item = z.infer<typeof Item>;

--- a/plugins/apt/package.json
+++ b/plugins/apt/package.json
@@ -6,7 +6,7 @@
   "types": "src/index.ts",
   "scripts": {
     "lint": "biome lint .",
-    "test": "echo 'no tests'"
+    "test": "bun test"
   },
   "dependencies": {
     "@dot-steward/core": "workspace:*"

--- a/plugins/apt/src/__tests__/pkg.test.ts
+++ b/plugins/apt/src/__tests__/pkg.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { pkg, plugin } from "..";
+
+describe("apt pkg", () => {
+  test("creates from string", () => {
+    expect(pkg("vim")).toEqual({ plugin: "apt", kind: "pkg", id: "vim" });
+  });
+
+  test("creates from object", () => {
+    expect(pkg({ id: "curl" })).toEqual({
+      plugin: "apt",
+      kind: "pkg",
+      id: "curl",
+    });
+  });
+
+  test("validates with plugin schema", () => {
+    const item = pkg("git");
+    expect(plugin.schema.parse(item)).toEqual(item);
+  });
+});

--- a/plugins/brew/package.json
+++ b/plugins/brew/package.json
@@ -6,7 +6,7 @@
   "types": "src/index.ts",
   "scripts": {
     "lint": "biome lint .",
-    "test": "echo 'no tests'"
+    "test": "bun test"
   },
   "dependencies": {
     "@dot-steward/core": "workspace:*"

--- a/plugins/brew/src/__tests__/brew.test.ts
+++ b/plugins/brew/src/__tests__/brew.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { tap, formula, cask, plugin } from "..";
+
+describe("brew functions", () => {
+  test("creates tap", () => {
+    expect(tap("homebrew/cask")).toEqual({
+      plugin: "brew",
+      kind: "tap",
+      id: "homebrew/cask",
+    });
+  });
+
+  test("creates formula", () => {
+    expect(formula({ id: "node" })).toEqual({
+      plugin: "brew",
+      kind: "formula",
+      id: "node",
+    });
+  });
+
+  test("creates cask", () => {
+    expect(cask("google-chrome")).toEqual({
+      plugin: "brew",
+      kind: "cask",
+      id: "google-chrome",
+    });
+  });
+
+  test("validates with plugin schema", () => {
+    const item = formula("bun");
+    expect(plugin.schema.parse(item)).toEqual(item);
+  });
+});

--- a/plugins/command/package.json
+++ b/plugins/command/package.json
@@ -6,7 +6,7 @@
   "types": "src/index.ts",
   "scripts": {
     "lint": "biome lint .",
-    "test": "echo 'no tests'"
+    "test": "bun test"
   },
   "dependencies": {
     "@dot-steward/core": "workspace:*"

--- a/plugins/command/src/__tests__/cmd.test.ts
+++ b/plugins/command/src/__tests__/cmd.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { cmd, plugin } from "..";
+
+describe("command cmd", () => {
+  test("creates from string", () => {
+    const item = cmd("update", "echo ok", "echo run");
+    expect(item).toEqual({
+      plugin: "command",
+      kind: "cmd",
+      id: "update",
+      check: "echo ok",
+      apply: "echo run",
+    });
+  });
+
+  test("creates from object", () => {
+    const input = { id: "install", check: "which foo", apply: "install foo" };
+    expect(cmd(input)).toEqual({ plugin: "command", kind: "cmd", ...input });
+  });
+
+  test("throws when missing check or apply", () => {
+    // @ts-expect-error missing apply
+    expect(() => cmd("bad", "ok")).toThrow("check and apply are required");
+  });
+
+  test("validates with plugin schema", () => {
+    const item = cmd("id1", "echo", "run");
+    expect(plugin.schema.parse(item)).toEqual(item);
+  });
+});

--- a/plugins/file/package.json
+++ b/plugins/file/package.json
@@ -6,7 +6,7 @@
   "types": "src/index.ts",
   "scripts": {
     "lint": "biome lint .",
-    "test": "echo 'no tests'"
+    "test": "bun test"
   },
   "dependencies": {
     "@dot-steward/core": "workspace:*"

--- a/plugins/file/src/__tests__/file.test.ts
+++ b/plugins/file/src/__tests__/file.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { ensure, dir, symlink, plugin } from "..";
+
+describe("file plugin", () => {
+  test("ensure from string", () => {
+    expect(ensure("cfg", "/tmp/config", "content")).toEqual({
+      plugin: "file",
+      kind: "ensure",
+      id: "cfg",
+      path: "/tmp/config",
+      content: "content",
+    });
+  });
+
+  test("ensure from object defaults content", () => {
+    expect(ensure({ id: "cfg", path: "/tmp/config" })).toEqual({
+      plugin: "file",
+      kind: "ensure",
+      id: "cfg",
+      path: "/tmp/config",
+      content: "",
+    });
+  });
+
+  test("dir", () => {
+    expect(dir("data", "/var/data")).toEqual({
+      plugin: "file",
+      kind: "dir",
+      id: "data",
+      path: "/var/data",
+    });
+  });
+
+  test("symlink", () => {
+    expect(
+      symlink({ id: "link", path: "/tmp/link", target: "/tmp/target" }),
+    ).toEqual({
+      plugin: "file",
+      kind: "symlink",
+      id: "link",
+      path: "/tmp/link",
+      target: "/tmp/target",
+    });
+  });
+
+  test("ensure throws without path", () => {
+    // @ts-expect-error missing path
+    expect(() => ensure("bad")).toThrow("path is required");
+  });
+
+  test("symlink throws without target", () => {
+    // @ts-expect-error missing target
+    expect(() => symlink("bad", "/tmp/link")).toThrow(
+      "path and target are required",
+    );
+  });
+
+  test("validate with plugin schema", () => {
+    const item = dir("data", "/var/data");
+    expect(plugin.schema.parse(item)).toEqual(item);
+  });
+});

--- a/plugins/shell/package.json
+++ b/plugins/shell/package.json
@@ -6,7 +6,7 @@
   "types": "src/index.ts",
   "scripts": {
     "lint": "biome lint .",
-    "test": "echo 'no tests'"
+    "test": "bun test"
   },
   "dependencies": {
     "@dot-steward/core": "workspace:*"

--- a/plugins/shell/src/__tests__/shell.test.ts
+++ b/plugins/shell/src/__tests__/shell.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { env, alias, path, ShellConfig, plugin } from "..";
+
+describe("shell plugin", () => {
+  test("env from string", () => {
+    expect(env("e", "KEY", "val")).toEqual({
+      plugin: "shell",
+      kind: "env",
+      id: "e",
+      key: "KEY",
+      value: "val",
+    });
+  });
+
+  test("alias from object", () => {
+    const input = { id: "ls", name: "ll", command: "ls -la" };
+    expect(alias(input)).toEqual({ plugin: "shell", kind: "alias", ...input });
+  });
+
+  test("path", () => {
+    expect(path("p", "/usr/bin")).toEqual({
+      plugin: "shell",
+      kind: "path",
+      id: "p",
+      dir: "/usr/bin",
+    });
+  });
+
+  test("throws when missing values", () => {
+    // @ts-expect-error missing key/value
+    expect(() => env("bad")).toThrow("key and value are required");
+    // @ts-expect-error missing command
+    expect(() => alias("bad", "ll")).toThrow("name and command are required");
+    // @ts-expect-error missing dir
+    expect(() => path("bad")).toThrow("dir is required");
+  });
+
+  test("ShellConfig renders collected items", () => {
+    const config = new ShellConfig();
+    config.collect(env("e1", "KEY", "value"));
+    config.collect(path("p1", "/usr/bin"));
+    config.collect(alias("a1", "ll", "ls -la"));
+    const expected =
+      'export KEY="value"\nexport PATH="/usr/bin:$PATH"\nalias ll=\'ls -la\'';
+    expect(config.render("bash")).toBe(expected);
+    expect(config.renderAll().bash).toBe(expected);
+  });
+
+  test("plugin schema parses items", () => {
+    const item = env("id", "K", "V");
+    expect(plugin.schema.parse(item)).toEqual(item);
+  });
+});


### PR DESCRIPTION
## Summary
- add test workflow to run lint and tests on pull requests
- add unit tests for core library and all plugins
- unify top-level item schema with union type

## Testing
- `bun run lint:fix`
- `bun run format`
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68b62834f88c832f8464198ad36a4bf4