### PR TITLE
Add bun tests and split CI for lint and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: "1.x"
+          cache: true
+      - run: bun install --no-save
+      - run: bun run lint
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: "1.x"
+          cache: true
+      - run: bun install --no-save
+      - run: bun test

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "lint": "biome check . && bun run scripts/check-static-this.mjs && bun run scripts/check-empty-lines.mjs",
     "lint:static-this": "bun run scripts/check-static-this.mjs",
-    "format": "biome format --write ."
+    "format": "biome format --write .",
+    "test": "bun test"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.8.3",

--- a/packages/core/test/matching.test.ts
+++ b/packages/core/test/matching.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test";
+import {
+  type HostContextLike,
+  all,
+  any,
+  arch,
+  env_var,
+  evalMatchExpr,
+  home,
+} from "../src/host/matching.ts";
+
+const ctx: HostContextLike = {
+  os: "linux",
+  arch: "x86_64",
+  hostname: "example",
+  env: { variables: { FOO: "bar" }, ci: false, devcontainer: false },
+  user: {
+    name: "alice",
+    uid: "1000",
+    gid: "1000",
+    home: "/home/alice",
+    can_sudo: true,
+    is_root: false,
+  },
+};
+
+test("matches architecture", () => {
+  expect(evalMatchExpr(ctx, arch("x86_64"))).toBe(true);
+  expect(evalMatchExpr(ctx, arch("arm64"))).toBe(false);
+});
+
+test("all and any expressions", () => {
+  expect(evalMatchExpr(ctx, all(arch("x86_64"), home("/home/alice")))).toBe(
+    true,
+  );
+  expect(evalMatchExpr(ctx, any(arch("arm64"), home("/home/bob")))).toBe(false);
+});
+
+test("environment variable conditions", () => {
+  expect(evalMatchExpr(ctx, env_var("FOO"))).toBe(true);
+  expect(evalMatchExpr(ctx, env_var("BAR"))).toBe(false);
+  expect(evalMatchExpr(ctx, env_var("FOO", "bar"))).toBe(true);
+  expect(evalMatchExpr(ctx, env_var("FOO", "baz"))).toBe(false);
+});


### PR DESCRIPTION
## Summary
- add initial bun test verifying host matching utilities
- expose `bun test` npm script
- run lint and tests in separate GitHub Actions jobs

## Testing
- `bun run lint`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68bd9ad92c18832fa1c673a57991683c