### PR TITLE
feat(cli): add config validation command and stricter task checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ command = "rustup toolchain install stable"
 # Inspect execution order
 cargo run -- plan -c dot-steward.toml
 
+# Validate configuration structure and duplicate task names
+cargo run -- validate -c dot-steward.toml
+
 # Execute tasks sequentially
 cargo run -- apply -c dot-steward.toml
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,8 @@
 use std::fs;
 use std::path::Path;
+use std::{collections::HashSet, fmt::Write as _};
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
@@ -22,7 +23,40 @@ pub fn load_config(path: &Path) -> Result<Config> {
         .with_context(|| format!("failed to read config at {}", path.display()))?;
     let parsed: Config = toml::from_str(&raw)
         .with_context(|| format!("failed to parse config at {}", path.display()))?;
+    validate_config(&parsed)?;
     Ok(parsed)
+}
+
+fn validate_config(config: &Config) -> Result<()> {
+    if config.tasks.is_empty() {
+        bail!("config must contain at least one [[tasks]] entry");
+    }
+
+    let mut seen_names = HashSet::new();
+    let mut errors = Vec::new();
+
+    for (index, task) in config.tasks.iter().enumerate() {
+        let ordinal = index + 1;
+        if task.name.trim().is_empty() {
+            errors.push(format!("tasks[{ordinal}] has an empty name"));
+        } else if !seen_names.insert(task.name.clone()) {
+            errors.push(format!("duplicate task name '{}'", task.name));
+        }
+
+        if task.command.trim().is_empty() {
+            errors.push(format!("task '{}' has an empty command", task.name));
+        }
+    }
+
+    if errors.is_empty() {
+        return Ok(());
+    }
+
+    let mut message = String::from("invalid configuration:\n");
+    for issue in errors {
+        let _ = writeln!(message, "- {issue}");
+    }
+    bail!(message.trim_end().to_owned())
 }
 
 #[cfg(test)]
@@ -40,5 +74,28 @@ mod tests {
         let cfg: Config = toml::from_str(input).expect("toml should parse");
         assert_eq!(cfg.tasks.len(), 1);
         assert_eq!(cfg.tasks[0].name, "brew");
+    }
+
+    #[test]
+    fn rejects_duplicate_task_names() {
+        let cfg = Config {
+            tasks: vec![
+                Task {
+                    name: "bootstrap".to_owned(),
+                    command: "echo first".to_owned(),
+                    description: None,
+                },
+                Task {
+                    name: "bootstrap".to_owned(),
+                    command: "echo second".to_owned(),
+                    description: None,
+                },
+            ],
+        };
+
+        let error = validate_config(&cfg).expect_err("expected duplicate-name validation error");
+        assert!(error
+            .to_string()
+            .contains("duplicate task name 'bootstrap'"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,12 @@ enum Commands {
         #[arg(short, long, default_value = "dot-steward.toml")]
         config: PathBuf,
     },
+    /// Validate config and exit without printing a plan or running commands
+    Validate {
+        /// Path to TOML config file
+        #[arg(short, long, default_value = "dot-steward.toml")]
+        config: PathBuf,
+    },
 }
 
 fn main() -> Result<()> {
@@ -45,6 +51,10 @@ fn main() -> Result<()> {
             let cfg = load_config(&config)?;
             run_apply(&cfg)?;
             println!("Apply complete.");
+        }
+        Commands::Validate { config } => {
+            load_config(&config)?;
+            println!("Config is valid.");
         }
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -6,9 +6,12 @@ use anyhow::{bail, Context, Result};
 use crate::config::{Config, Task};
 
 pub fn render_plan(config: &Config) -> String {
-    let mut output = String::from("Plan:\n");
+    let mut output = format!("Plan ({} tasks):\n", config.tasks.len());
     for (index, task) in config.tasks.iter().enumerate() {
         let _ = writeln!(output, "{}. {} -> {}", index + 1, task.name, task.command);
+        if let Some(description) = task.description.as_deref() {
+            let _ = writeln!(output, "   description: {description}");
+        }
     }
     output
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -24,5 +24,33 @@ fn plan_prints_task_summary() {
         .arg(&config_path)
         .assert()
         .success()
+        .stdout(predicate::str::contains("Plan (1 tasks):"))
         .stdout(predicate::str::contains("echo-task"));
+}
+
+#[test]
+fn validate_rejects_duplicate_task_names() {
+    let dir = tempdir().expect("tempdir");
+    let config_path = dir.path().join("dot-steward.toml");
+
+    fs::write(
+        &config_path,
+        r#"
+        [[tasks]]
+        name = "dupe"
+        command = "echo first"
+
+        [[tasks]]
+        name = "dupe"
+        command = "echo second"
+        "#,
+    )
+    .expect("write config");
+
+    Command::new(env!("CARGO_BIN_EXE_dot-steward"))
+        .args(["validate", "-c"])
+        .arg(&config_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("duplicate task name 'dupe'"));
 }


### PR DESCRIPTION
### Motivation

- Improve safety by validating configuration early to avoid running or planning against broken task files. 
- Provide clearer operator feedback for common issues like duplicate names, empty commands, or missing tasks. 
- Make `plan` output more informative so users can quickly review task counts and descriptions.

### Description

- Add `validate_config` which runs in `load_config` and checks for an empty `[[tasks]]` list, empty task names, empty commands, and duplicate task names (implemented in `src/config.rs` via `validate_config`).
- Add a `Validate` CLI subcommand so users can run `cargo run -- validate -c <file>` to verify config correctness without `plan` or `apply` (changes in `src/main.rs`).
- Enhance `render_plan` to include total task count and print optional per-task `description` lines (changes in `src/runner.rs`).
- Extend tests to assert the new plan header and that duplicate task names fail validation via the CLI, and update `README.md` to document the `validate` command (changes in `tests/cli.rs` and `README.md`).

### Testing

- Ran `cargo fmt --all` which completed successfully. 
- Ran `cargo clippy --all-targets --all-features` which completed without issues. 
- Ran `cargo test` and all unit and integration tests passed, including new tests for duplicate-name validation and plan header checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a4845c88832f968a049ab3001c5d)